### PR TITLE
Fixed a bug with ZSounds installer

### DIFF
--- a/src/installers.ts
+++ b/src/installers.ts
@@ -236,7 +236,7 @@ async function installCustomCar(files: string[], destinationPath: string): Promi
 //---------------------------------------------------------------------------------------------------------------
 async function checkIfZSound(files: string[], gameId: string): Promise<types.ISupportedResult> {
     const result = await containsDvFile(files, ZSOUNDS.configFile, gameId);
-    if (result.supported) {
+    if (!result.supported) {
         return result;
     }
     


### PR DESCRIPTION
The code was checking if "supported" was true to exit, but it should've been checking false. 

This means that mods for Stardew Valley would get flagged as requiring ZSounds. Test case: https://www.nexusmods.com/stardewvalley/mods/11517